### PR TITLE
use gopkg.in/check.v1 to avoid using launchpad.net/check which forces bzr usage.

### DIFF
--- a/link_test.go
+++ b/link_test.go
@@ -3,7 +3,7 @@ package link
 import (
 	"testing"
 
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.


### PR DESCRIPTION
https://github.com/go-check/check

Howdy, just because:
```
go mod why launchpad.net/gocheck

# launchpad.net/gocheck
github.com/hashicorp/packer/builder/digitalocean
github.com/digitalocean/godo
github.com/tent/http-link-go
github.com/tent/http-link-go.test
launchpad.net/gocheck
```