### PR TITLE
Updates dependency [launchpad.net/gocheck] -> [gopkg.in/check.v1]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.1
+  - 1.13
   - tip
 before_install:
-  - go get launchpad.net/gocheck
+  - go get gopkg.in/check.v1

--- a/link_test.go
+++ b/link_test.go
@@ -3,7 +3,7 @@ package link
 import (
 	"testing"
 
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.


### PR DESCRIPTION
- Can we update the "launchpad.net/gocheck" dependency to "gopkg.in/check.v1"?

The reason is that gocheck moved to a new repository (gopkg.in) and doesn't require installation of Bazaar anymore.