### PR TITLE
Adding Power support(ppc64le) with continuous integration/testing to support the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: go
+arch:
+  - amd64
+  - ppc64le
 go:
-  - 1.1
+  - 1.15
   - tip
 before_install:
+  - sudo apt-get install bzr
   - go get launchpad.net/gocheck


### PR DESCRIPTION
…the project for architecture independent


This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly, 
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.

I am part of IBM team and working on porting  power on ppc64le into open sources.